### PR TITLE
Implement RAII PageGuard for BufferPoolManager

### DIFF
--- a/src/buffer/buffer_pool_manager.cpp
+++ b/src/buffer/buffer_pool_manager.cpp
@@ -218,4 +218,57 @@ void BufferPoolManager::reset_cache_stats() {
   flushes_ = 0;
 }
 
+// --- PageGuard Implementation ---
+
+  PageGuard::PageGuard(PageGuard &&other) noexcept
+      : bpm_(other.bpm_), page_(other.page_), page_id_(other.page_id_), dirty_(other.dirty_) {
+    // Transfer ownership and nullify the source to prevent double-unpinning
+    other.bpm_ = nullptr;
+    other.page_ = nullptr;
+    other.page_id_ = INVALID_PAGE_ID;
+    other.dirty_ = false;
+  }
+
+  PageGuard &PageGuard::operator=(PageGuard &&other) noexcept {
+    if (this != &other) {
+      // Release existing resource before taking ownership of new one
+      drop();
+      bpm_ = other.bpm_;
+      page_ = other.page_;
+      page_id_ = other.page_id_;
+      dirty_ = other.dirty_;
+      
+      other.bpm_ = nullptr;
+      other.page_ = nullptr;
+      other.page_id_ = INVALID_PAGE_ID;
+      other.dirty_ = false;
+    }
+    return *this;
+  }
+
+  void PageGuard::drop() {
+    if (bpm_ != nullptr && page_id_ != INVALID_PAGE_ID) {
+      // Automatically call the manager's unpin logic
+      bpm_->unpin_page(page_id_, dirty_);
+    }
+    bpm_ = nullptr;
+    page_ = nullptr;
+    page_id_ = INVALID_PAGE_ID;
+    dirty_ = false;
+  }
+
+  // --- BufferPoolManager Guard APIs ---
+
+  PageGuard BufferPoolManager::fetch_page_guard(page_id_t page_id) {
+    // Wrap the standard fetch_page result in an RAII guard
+    Page *page = fetch_page(page_id);
+    return {this, page, page_id};
+  }
+
+  PageGuard BufferPoolManager::new_page_guard(page_id_t page_id) {
+    // Wrap the standard new_page result in an RAII guard
+    Page *page = new_page(page_id);
+    return {this, page, page_id};
+  }
+
 }  // namespace letty

--- a/src/buffer/buffer_pool_manager.h
+++ b/src/buffer/buffer_pool_manager.h
@@ -14,6 +14,52 @@
 
 namespace letty {
 
+class BufferPoolManager; // Forward declaration
+
+/**
+ * @class PageGuard
+ * @brief RAII handle for a page in the buffer pool. 
+ *        Automatically unpins the page when it goes out of scope.
+ */
+class PageGuard {
+ public:
+  PageGuard() = default;
+
+  /** @brief Constructor used by BufferPoolManager. */
+  PageGuard(BufferPoolManager *bpm, Page *page, page_id_t page_id)
+      : bpm_(bpm), page_(page), page_id_(page_id) {}
+
+  /** @brief Destructor automatically calls drop() to unpin the page. */
+  ~PageGuard() { drop(); }
+
+  // Non-copyable, prevents multiple unpins for the same page
+  PageGuard(const PageGuard &) = delete;
+  PageGuard &operator=(const PageGuard &) = delete;
+
+  /** @brief Move constructor transfers ownership of the page pin. */
+  PageGuard(PageGuard &&other) noexcept;
+  /** @brief Move assignment transfers ownership of the page pin. */
+  PageGuard& operator=(PageGuard &&other) noexcept;
+
+  /** @brief Returns pointer to the underlying page. */
+  Page *get() const { return page_; }
+  Page &operator*() const { return *page_; }
+  Page *operator->() const { return page_; }
+  explicit operator bool() const { return page_ != nullptr; }
+
+  /** @brief Marks the page as dirty so it is written back on eviction. */
+  void mark_dirty() { dirty_ = true; }
+
+  /** @brief Manually releases the page pin before the guard goes out of scope. */
+  void drop();
+
+ private:
+  BufferPoolManager *bpm_ = nullptr;
+  Page *page_ = nullptr;
+  page_id_t page_id_ = INVALID_PAGE_ID;
+  bool dirty_ = false;
+};
+
 /** @brief Snapshot of buffer pool cache performance counters. */
 struct CacheStats {
   uint64_t hits             = 0;
@@ -76,6 +122,20 @@ class BufferPoolManager {
    * @return Pointer to the Page (pin_count=1, dirty=true), or nullptr if pool is full.
    */
   Page* new_page(page_id_t page_id);
+  
+  /**
+   * @brief Fetch a page from the pool and return an RAII guard.
+   * @param page_id The page to fetch.
+   * @return PageGuard holding the page, or empty guard if fetch fails.
+   */
+  PageGuard fetch_page_guard(page_id_t page_id);
+
+  /**
+   * @brief Register a new page and return an RAII guard.
+   * @param page_id The page ID assigned by the caller.
+   * @return PageGuard holding the new page, or empty guard if creation fails.
+   */
+  PageGuard new_page_guard(page_id_t page_id);
 
   /**
    * @brief Write a dirty page to disk without unpinning or evicting it.


### PR DESCRIPTION
Introduces PageGuard, an RAII-based handle for buffer pool pages. This implementation automates the unpin_page process, ensuring that pins are released as soon as the guard goes out of scope. This effectively eliminates potential PIN leaks caused by manual management and multiple exit points in the codebase.